### PR TITLE
Update replace-version-and-registry action

### DIFF
--- a/replace-version-and-registry/__tests__/functions.test.ts
+++ b/replace-version-and-registry/__tests__/functions.test.ts
@@ -1,30 +1,80 @@
 import { updateManifest } from '../src/functions'
 
-const before = 
+test('update manifest, no tags', async () => {
+
+    const before = 
 `name: sql-server-always-on
 version: 0.1.0
 description: SQL Server Always On for AKS
 dockerfile: cnab/app/Dockerfile.base
-invocationImage: 'cnabquickstarts.azurecr.io/porter/sql-server-always-on:latest'
-tag: 'cnabquickstarts.azurecr.io/porter/sql-server-always-on:latest'
+tag: 'cnabquickstarts.azurecr.io/porter/sql-server-always-on'
 `
-
-const after = 
+    
+    const after = 
 `name: sql-server-always-on
 version: 0.2.0-feature1.1
 description: SQL Server Always On for AKS
 dockerfile: cnab/app/Dockerfile.base
-invocationImage: 'myregistry.io/porter/sql-server-always-on:0.2.0-feature1.1'
-tag: 'myregistry.io/porter/sql-server-always-on:0.2.0-feature1.1'
+tag: myregistry.io/porter/sql-server-always-on
 `
 
-test('update manifest is correct', async () => {
-
     let version = "0.2.0-feature1.1"
-    let tag = "0.2.0-feature1.1"
     let registry = "myregistry.io"
 
-    let manifestContents = updateManifest(before, version, tag, registry);
+    let manifestContents = updateManifest(before, version, registry);
+
+    expect(manifestContents).toBe(after);
+});
+
+test('update manifest, tag in original', async () => {
+
+    const before = 
+`name: sql-server-always-on
+version: 0.1.0
+description: SQL Server Always On for AKS
+dockerfile: cnab/app/Dockerfile.base
+tag: 'cnabquickstarts.azurecr.io/porter/sql-server-always-on:customtag'
+`
+    
+    const after = 
+`name: sql-server-always-on
+version: 0.2.0-feature1.1
+description: SQL Server Always On for AKS
+dockerfile: cnab/app/Dockerfile.base
+tag: myregistry.io/porter/sql-server-always-on
+`
+
+    let version = "0.2.0-feature1.1"
+    let registry = "myregistry.io"
+
+    let manifestContents = updateManifest(before, version, registry);
+
+    expect(manifestContents).toBe(after);
+});
+
+test('update manifest, tag in original and new tag', async () => {
+
+    const before = 
+`name: sql-server-always-on
+version: 0.1.0
+description: SQL Server Always On for AKS
+dockerfile: cnab/app/Dockerfile.base
+tag: 'cnabquickstarts.azurecr.io/porter/sql-server-always-on:customtag'
+`
+    
+    const after = 
+`name: sql-server-always-on
+version: 0.2.0-feature1.1
+description: SQL Server Always On for AKS
+dockerfile: cnab/app/Dockerfile.base
+tag: 'myregistry.io/porter/sql-server-always-on:latest'
+`
+
+    let version = "0.2.0-feature1.1"
+    let registry = "myregistry.io"
+    let tag = "latest"
+
+    let manifestContents = updateManifest(before, version, registry, tag);
 
     expect(manifestContents).toBe(after);
 });

--- a/replace-version-and-registry/action.yml
+++ b/replace-version-and-registry/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   tag:
     description: 'The tag to replace with'
-    required: true
+    required: false
   registry:
     description: 'The registry to replace with'
     required: true

--- a/replace-version-and-registry/dist/index.js
+++ b/replace-version-and-registry/dist/index.js
@@ -659,17 +659,16 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const yaml = __importStar(__webpack_require__(414));
 const docker_reference_parser_1 = __webpack_require__(954);
-function updateManifest(manifestContents, version, tag, registry) {
+function updateManifest(manifestContents, version, registry, tag) {
     let manifest = yaml.safeLoad(manifestContents);
     manifest.version = version;
-    let invocationImage = manifest.invocationImage;
-    let invocationImageParsed = docker_reference_parser_1.parse(invocationImage);
-    invocationImage = `${registry}/${invocationImageParsed.path}:${tag}`;
-    manifest.invocationImage = invocationImage;
     let bundle = manifest.tag;
     let bundleParsed = docker_reference_parser_1.parse(bundle);
-    bundle = `${registry}/${bundleParsed.path}:${tag}`;
-    manifest.tag = bundle;
+    let newBundle = `${registry}/${bundleParsed.path}`;
+    if (tag) {
+        newBundle += `:${tag}`;
+    }
+    manifest.tag = newBundle;
     manifestContents = yaml.safeDump(manifest);
     return manifestContents;
 }
@@ -711,7 +710,7 @@ function run() {
             let tag = core.getInput("tag");
             let registry = core.getInput("registry");
             let manifestContents = yield fs_1.promises.readFile(manifestPath, 'utf8');
-            manifestContents = functions_1.updateManifest(manifestContents, version, tag, registry);
+            manifestContents = functions_1.updateManifest(manifestContents, version, registry, tag);
             core.info("Updated manifest:\n");
             core.info(manifestContents);
             yield fs_1.promises.writeFile(manifestPath, manifestContents);

--- a/replace-version-and-registry/lib/functions.js
+++ b/replace-version-and-registry/lib/functions.js
@@ -9,17 +9,16 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const yaml = __importStar(require("js-yaml"));
 const docker_reference_parser_1 = require("docker-reference-parser");
-function updateManifest(manifestContents, version, tag, registry) {
+function updateManifest(manifestContents, version, registry, tag) {
     let manifest = yaml.safeLoad(manifestContents);
     manifest.version = version;
-    let invocationImage = manifest.invocationImage;
-    let invocationImageParsed = docker_reference_parser_1.parse(invocationImage);
-    invocationImage = `${registry}/${invocationImageParsed.path}:${tag}`;
-    manifest.invocationImage = invocationImage;
     let bundle = manifest.tag;
     let bundleParsed = docker_reference_parser_1.parse(bundle);
-    bundle = `${registry}/${bundleParsed.path}:${tag}`;
-    manifest.tag = bundle;
+    let newBundle = `${registry}/${bundleParsed.path}`;
+    if (tag) {
+        newBundle += `:${tag}`;
+    }
+    manifest.tag = newBundle;
     manifestContents = yaml.safeDump(manifest);
     return manifestContents;
 }

--- a/replace-version-and-registry/lib/main.js
+++ b/replace-version-and-registry/lib/main.js
@@ -27,7 +27,7 @@ function run() {
             let tag = core.getInput("tag");
             let registry = core.getInput("registry");
             let manifestContents = yield fs_1.promises.readFile(manifestPath, 'utf8');
-            manifestContents = functions_1.updateManifest(manifestContents, version, tag, registry);
+            manifestContents = functions_1.updateManifest(manifestContents, version, registry, tag);
             core.info("Updated manifest:\n");
             core.info(manifestContents);
             yield fs_1.promises.writeFile(manifestPath, manifestContents);

--- a/replace-version-and-registry/src/functions.ts
+++ b/replace-version-and-registry/src/functions.ts
@@ -1,20 +1,19 @@
 import * as yaml from 'js-yaml'
 import { parse } from 'docker-reference-parser';
 
-export function updateManifest(manifestContents: string, version: string, tag: string, registry: string) : string {
+export function updateManifest(manifestContents: string, version: string, registry: string, tag?: string) : string {
     let manifest = yaml.safeLoad(manifestContents);
 
     manifest.version = version;
 
-    let invocationImage = manifest.invocationImage;
-    let invocationImageParsed = parse(invocationImage);
-    invocationImage = `${registry}/${invocationImageParsed.path}:${tag}`;
-    manifest.invocationImage = invocationImage;
-    
     let bundle = manifest.tag;
     let bundleParsed = parse(bundle);
-    bundle = `${registry}/${bundleParsed.path}:${tag}`;
-    manifest.tag = bundle;
+
+    let newBundle = `${registry}/${bundleParsed.path}`;
+    if (tag) {
+        newBundle += `:${tag}`
+    }
+    manifest.tag = newBundle;
 
     manifestContents = yaml.safeDump(manifest);
 

--- a/replace-version-and-registry/src/main.ts
+++ b/replace-version-and-registry/src/main.ts
@@ -12,7 +12,7 @@ export async function run() {
 
     let manifestContents = await fs.readFile(manifestPath, 'utf8');
 
-    manifestContents = updateManifest(manifestContents, version, tag, registry);
+    manifestContents = updateManifest(manifestContents, version, registry, tag);
 
     core.info("Updated manifest:\n");
     core.info(manifestContents);


### PR DESCRIPTION
Porter changed the schema of the manifest (there is no longer an `invocationImage` property, now just `tag`), so we have to update the action responsible for replacing the version/registry in the manifest.